### PR TITLE
Add Docker and OpenAPI configurations with Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+SHELL = /bin/bash
+
+up:
+	docker compose up -d
+
+build:
+	docker compose build
+
+down:
+	docker compose down

--- a/containers/swagger/Dockerfile
+++ b/containers/swagger/Dockerfile
@@ -1,0 +1,1 @@
+FROM swaggerapi/swagger-ui

--- a/containers/swagger/Dockerfile
+++ b/containers/swagger/Dockerfile
@@ -1,1 +1,1 @@
-FROM swaggerapi/swagger-ui
+FROM swaggerapi/swagger-ui:v5.17.14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  docs:
+    container_name: docs
+    build:
+      context: .
+      dockerfile: containers/swagger/Dockerfile
+    volumes:
+      - ./docs/openapi.yml:/openapi/openapi.yml
+    environment:
+      - SWAGGER_JSON=/openapi/openapi.yml
+    ports:
+      - 9000:8080
+    networks:
+      - rust_back_web
+networks:
+  rust_back_web:
+    external: false

--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -1,0 +1,31 @@
+# https://swagger.io/tools/swagger-ui/
+openapi: 3.0.3
+info:
+  title: rust_backend_practice
+  description: |-
+    # Rustのバックエンド練習
+  version: 1.0.1
+servers:
+  - url: http://localhost:8000/
+tags:
+  - name: health
+    description: ヘルスチェック用のAPI
+paths:
+  /api/health:
+    get:
+      tags:
+        - health
+      summary: ヘルスチェックAPI
+      description: APIサーバー単独でのヘルスチェック
+      responses:
+        '200':
+          description: 成功
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    description: ステータス
+                    example: pass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Dockerコンテナの管理を行うための`Makefile`ターゲットを追加しました。（`up`, `build`, `down`）
  - ドキュメントコンテナのサービス構成を行う`docker-compose.yml`を追加しました。
  - OpenAPI仕様書を定義する`openapi.yml`を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->